### PR TITLE
fix: 배가 특정 사각형에서만 존재하는 현상 해결

### DIFF
--- a/Center_ShipEmulator/Views/ShipEmulatorView.cs
+++ b/Center_ShipEmulator/Views/ShipEmulatorView.cs
@@ -47,7 +47,7 @@ namespace ShipEmulator
             gMap_Main.Position = new PointLatLng(37.2328660, 131.8654529);
             gMap_Main.MinZoom = 10;
             gMap_Main.MaxZoom = 50;
-            gMap_Main.Zoom = 14;
+            gMap_Main.Zoom = 12;
             gMap_Main.ShowCenter = false;
 
             DrawPoint = new GMapOverlay("point");
@@ -117,9 +117,11 @@ namespace ShipEmulator
 
                     mDatabaseHelper.AddGPS(gps);
                     AddPoint(Latitude, Longitude);
+                    
 
                     Invoke(new Action(() =>
                     {
+                        gMap_Main.Position = new PointLatLng((double)Latitude, (double)Longitude);
                         Label_Text_Sentence.Text = $"{gpsData}";
                         Label_Text_Latitude.Text = $"{Latitude.ToString("F6")}도";
                         Label_Text_Longitude.Text = $"{Longitude.ToString("F6")}도";

--- a/Ship_ShipEmulator/Views/ShipEmulatorView.cs
+++ b/Ship_ShipEmulator/Views/ShipEmulatorView.cs
@@ -24,6 +24,8 @@ namespace Ship_ShipEmulator
         private int mRpmPort = 2424;
         private int mHz = 10;
         private int mRpm;
+        private double mLatitude = 37.2328660;
+        private double mLongitude = 131.8654529;
         public ShipEmulatorView()
         {
             InitializeComponent();
@@ -66,16 +68,16 @@ namespace Ship_ShipEmulator
 
         private string AddGPS()
         {
-            double latitude = 37.2328660 + random.NextDouble() * 0.005;
-            double longitude = 131.8654529 + random.NextDouble() * 0.005;
+            mLatitude += (random.NextDouble() - 0.5) * 0.03;
+            mLongitude += (random.NextDouble() - 0.5) * 0.03;
             string time = DateTime.UtcNow.ToString("HHmmss.fff");
 
-            int Degree_Latitude = (int)latitude;
-            double Minute_Latitude = (latitude - Degree_Latitude) * 60;
+            int Degree_Latitude = (int)mLatitude;
+            double Minute_Latitude = (mLatitude - Degree_Latitude) * 60;
             string NMEA_Latitude = $"{Degree_Latitude}{Minute_Latitude:00.0000},N";
 
-            int Degree_Longitude = (int)longitude;
-            double Minute_Longitude = (longitude - Degree_Longitude) * 60;
+            int Degree_Longitude = (int)mLongitude;
+            double Minute_Longitude = (mLongitude - Degree_Longitude) * 60;
             string NMEA_Longitude = $"{Degree_Longitude}{Minute_Longitude:00.0000},E";
 
             return $"$GPGGA,{time},{NMEA_Latitude},{NMEA_Longitude},1,03,23,23,M,23,M,0.0,0000*23";


### PR DESCRIPTION
오류 : 위도가 고정되어있고 그 안에서만 난수를 주다보니, 오랫동안 돌리면 사각형 내에 전부 점이 찍히는 문제가 있었음.

해결 : 매번 위도와 경도를 과거에 점을 찍은 위치로 한정지으면서 조금 더 자연스럽게 느껴지게끔 작업함.

- 로직 해결
- 해당 점을 화면이 따라가게 진행함.